### PR TITLE
Feature test bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ User Story #6: When my markdown previewer first loads, the default markdown in t
 
 Optional Bonus (you do not need to make this test pass): My markdown previewer interprets carriage returns and renders them as br (line break) elements.
 
-You can build your project by forking this CodePen pen. Or you can use this CDN link to run the tests in any environment you like: https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js
+You can build your project by forking [this CodePen pen](https://codepen.io/freeCodeCamp/pen/MJjpwO ). Or you can use this CDN link to run the tests in any environment you like: https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+  <script src="https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js"></script>
 </body>
 
 </html>

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -5,7 +5,16 @@ import highlightJs from "highlight.js";
 
 Marked.setOptions({
     langPrefix: "language-",
+    // makes Marked.JS to hide Exceptions
     silent: true,
+
+    // makes Marked.JS to support Github-flavored Markdown
+    gfm: true,
+
+    // uses <br /> tags on a single-line breaks
+    breaks: true,
+
+    // highlighting code block function
     highlight: (function (module) {
         return function (code, language) {
             return module.highlightAuto(

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-//import App from './App';
-import { Presentational } from "./reactReduxConnection";
+import AppWrapper from "./AppWrapper";
 import * as serviceWorker from './serviceWorker';
 
-//ReactDOM.render(<App />, document.getElementById('root'));
-
-ReactDOM.render(<Presentational />, document.getElementById('root'));
+ReactDOM.render(<AppWrapper />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/reactReduxConnection.js
+++ b/src/reactReduxConnection.js
@@ -39,7 +39,7 @@ const mapDispatchToProps = function (dispatch) {
     };
 };
 
-export class Presentational extends React.Component {
+class Presentational extends React.Component {
     constructor(props) {
         super(props);
 

--- a/src/readDefaultContent.js
+++ b/src/readDefaultContent.js
@@ -16,7 +16,7 @@ export default function readDefaultContent() {
         "To bold a word or phrase, just surround it with a pair of stars **in this way**.\n" +
         "\n" +
         "### Italics\n" +
-        "Very similar to the bold font, surround a word or phrase with just one star *in exactly this way *.\n" +
+        "Very similar to the bold font, surround a word or phrase with just one star *in exactly this way*.\n" +
         "\n" +
         "### Blockquote\n" +
         "To style a text as a blockquote, just introduce the paragraph with a > symbol: \n" +

--- a/src/readDefaultContent.js
+++ b/src/readDefaultContent.js
@@ -1,6 +1,5 @@
 export default function readDefaultContent() {
-    return "This is a Markdown previewer\n" +
-        "----------------------------\n" +
+    return "# This is a Markdown previewer\n" +
         "\n" +
         "A Markdown previewer can help you to produce HTML code in a fast and easy way: \n" +
         "\n" +
@@ -14,7 +13,7 @@ export default function readDefaultContent() {
         "The level of a subheading can be set with the same number of hashes: if you want a heading 2, insert 2 hashes; a heading 3, insert 3 hashes, etc.\n" +
         "\n" +
         "### Bold text\n" +
-        "To bold a word or phrase, just surround it with a pair of stars **in this way **.\n" +
+        "To bold a word or phrase, just surround it with a pair of stars **in this way**.\n" +
         "\n" +
         "### Italics\n" +
         "Very similar to the bold font, surround a word or phrase with just one star *in exactly this way *.\n" +


### PR DESCRIPTION
Here, I implemented FreeCodeCamp test bundle to detect if the app passes the tests. At the moment of writing this message, it passes every test.

There were corrections in README and changes in the MarkedJS options to allow the use of `<br />` tags in the Preview component.

However, I did something out of place: the commit [b8a1dec](https://github.com/rafael-atias/markdown-previewer/commit/b8a1dec740f7a629fe56dc2bc4366be2493fd701) shows I corrected what component was rendered in `index.js`.

Because of its importance, I believed this error had to be patched immediately, instead of waiting to implement the actual feature and *then* create a new branch to fix this error.