### PR TITLE
forces rel="noopener noreferrer" in every link

### DIFF
--- a/src/reactComponents/Preview.js
+++ b/src/reactComponents/Preview.js
@@ -3,30 +3,77 @@ import Marked from "marked";
 import DOMPurify from "dompurify";
 import highlightJs from "highlight.js";
 
-Marked.setOptions({
-    langPrefix: "language-",
-    // makes Marked.JS to hide Exceptions
-    silent: true,
+/**
+ * Object -> (String -> String)
+ * 
+ * consumes a sanitizer, configures it and returns a function that
+ * will consume the input to sanitize
+ * 
+ * @param {Object} sanitizer The sanitizer object
+ * @returns {(Function} The sanitizer function
+ */
+const inputSanitizerFactory = function (sanitizer) {
+    /**
+     * to prevent tab nabbing
+     * 
+     * @see https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing
+     */
+    sanitizer.addHook("afterSanitizeAttributes", function (htmlNode) {
+        if (htmlNode.nodeName.toLowerCase() === "a") {
+            htmlNode.setAttribute("target", "_blank"); // to avoid the user loses its work if clicks on by accident
+            htmlNode.setAttribute("rel", "noopener noreferrer");
+        }
+    });
 
-    // makes Marked.JS to support Github-flavored Markdown
-    gfm: true,
+    return function (input) {
+        return sanitizer.sanitize(input);
+    };
+};
 
-    // uses <br /> tags on a single-line breaks
-    breaks: true,
+/**
+ * Object -> (String -> String)
+ * 
+ * Consumes a Markdown parser object, configures it 
+ * and returns a function that will consume the input
+ * to be parsed
+ * 
+ * @param {Object} mdParser 
+ * @returns {Function} The parser function
+ */
+const configuredMarkdownParserFactory = function (mdParser) {
+    mdParser.setOptions({
+        langPrefix: "language-",
+        // makes Marked.JS to hide Exceptions
+        silent: true,
 
-    // highlighting code block function
-    highlight: (function (module) {
-        return function (code, language) {
-            return module.highlightAuto(
-                code,
-                [module.getLanguage(language) ? language : "plaintext"]
-            ).value;
-        };
-    })(highlightJs),
-});
+        // makes Marked.JS to support Github-flavored Markdown
+        gfm: true,
+
+        // uses <br /> tags on a single-line breaks
+        breaks: true,
+
+        // highlighting code block function
+        highlight: (function (module) {
+            return function (code, language) {
+                return module.highlightAuto(
+                    code,
+                    [module.getLanguage(language) ? language : "plaintext"]
+                ).value;
+            };
+        })(highlightJs),
+    });
+
+    return function (input) {
+        return mdParser(input);
+    };
+};
+
+const inputSanitizer = inputSanitizerFactory(DOMPurify);
+
+const configuredMdParser = configuredMarkdownParserFactory(Marked);
 
 export default function Preview(props) {
     return <div id="preview"
         className="layout"
-        dangerouslySetInnerHTML={({ __html: DOMPurify.sanitize(Marked(props.content)) })}></div>
+        dangerouslySetInnerHTML={({ __html: inputSanitizer(configuredMdParser(props.content)) })}></div>
 }


### PR DESCRIPTION
This bugfix forces the attribute `rel="noopener noreferrer"` in every link created through the preview.